### PR TITLE
Tests basepath handling

### DIFF
--- a/EchoPro/_testing.py
+++ b/EchoPro/_testing.py
@@ -1,0 +1,3 @@
+from pathlib import Path
+
+HERE = Path(__file__).parent.absolute()

--- a/EchoPro/tests/computation/test_transect_selection.py
+++ b/EchoPro/tests/computation/test_transect_selection.py
@@ -1,22 +1,18 @@
 import pytest
 
-import os
 import numpy as np
 import EchoPro
 from EchoPro.computation import SemiVariogram as SV
 
 
 def test_transect_selection_output(config_base_path):
-
-    # change working directory so no initialization files need to be modified
-    # TODO: this may not be necessary in the future
-    os.chdir(config_base_path)
-
     # initialize Survey object
-    survey_2019 = EchoPro.Survey(init_file_path='../config_files/initialization_config.yml',
-                                 survey_year_file_path='../config_files/survey_year_2019_config.yml',
-                                 source=3,
-                                 exclude_age1=True)
+    survey_2019 = EchoPro.Survey(
+        init_file_path=config_base_path / 'initialization_config.yml',
+        survey_year_file_path=config_base_path / 'survey_year_2019_config.yml',
+        source=3,
+        exclude_age1=True
+    )
 
     # load all data
     survey_2019.load_survey_data()
@@ -63,18 +59,15 @@ def test_transect_selection_output(config_base_path):
 
 
 def test_all_transects_selected_output(config_base_path):
-
     # The biomass produced should be the same as the case where no transects are selected
 
-    # change working directory so no initialization files need to be modified
-    # TODO: this may not be necessary in the future
-    os.chdir(config_base_path)
-
     # initialize Survey object
-    survey_2019 = EchoPro.Survey(init_file_path='../config_files/initialization_config.yml',
-                                 survey_year_file_path='../config_files/survey_year_2019_config.yml',
-                                 source=3,
-                                 exclude_age1=True)
+    survey_2019 = EchoPro.Survey(
+        init_file_path=config_base_path / 'initialization_config.yml',
+        survey_year_file_path=config_base_path / 'survey_year_2019_config.yml',
+        source=3,
+        exclude_age1=True
+    )
 
     # load all data
     survey_2019.load_survey_data()

--- a/EchoPro/tests/conftest.py
+++ b/EchoPro/tests/conftest.py
@@ -42,4 +42,4 @@ def matlab_output_base_path() -> pathlib.Path:
     pathlib.Path
         The base directory path for the Matlab output files
     """
-    return pathlib.Path("/usr/mayorgadat/workmain/acoustics/2021-NWFSC-EchoPro-HakeIGP/EchoPro/EchoProPython/outputs/EchoPro_matlab_output_brandon_age_22_end_bin/")
+    return pathlib.Path("<YOUR-OUTPUTS-BASEPATH>/EchoProPython/outputs/EchoPro_matlab_output_brandon_age_22_end_bin/")

--- a/EchoPro/tests/conftest.py
+++ b/EchoPro/tests/conftest.py
@@ -3,6 +3,8 @@
 import pytest
 import pathlib
 
+from EchoPro._testing import HERE
+
 
 @pytest.fixture(scope="session")
 def config_base_path() -> pathlib.Path:
@@ -14,7 +16,7 @@ def config_base_path() -> pathlib.Path:
     pathlib.Path
         The base directory path for the configuration files
     """
-    return pathlib.Path("../../../example_notebooks")
+    return HERE / "../config_files"
 
 
 @pytest.fixture(scope="session")
@@ -27,7 +29,7 @@ def reports_base_path() -> pathlib.Path:
     pathlib.Path
         The base directory path for the reports
     """
-    return pathlib.Path("../EchoPro/tests/reports/EchoPro_python_output")
+    return HERE / "tests/reports/EchoPro_python_output"
 
 
 @pytest.fixture(scope="session")
@@ -40,4 +42,4 @@ def matlab_output_base_path() -> pathlib.Path:
     pathlib.Path
         The base directory path for the Matlab output files
     """
-    return pathlib.Path("/Users/brandonreyes/UW_work/EchoPro_work/UW_EchoProMatlab_Repackaged/outputs/EchoPro_matlab_output_brandon_age_22_end_bin")
+    return pathlib.Path("/usr/mayorgadat/workmain/acoustics/2021-NWFSC-EchoPro-HakeIGP/EchoPro/EchoProPython/outputs/EchoPro_matlab_output_brandon_age_22_end_bin/")

--- a/EchoPro/tests/kriging/test_kriging_output.py
+++ b/EchoPro/tests/kriging/test_kriging_output.py
@@ -1,6 +1,5 @@
 import pytest
 
-import os
 import pandas as pd
 import numpy as np
 import EchoPro
@@ -8,16 +7,13 @@ from EchoPro.computation import SemiVariogram as SV
 
 
 def test_biomass_age_output(config_base_path, matlab_output_base_path):
-
-    # change working directory so no initialization files need to be modified
-    # TODO: this may not be necessary in the future
-    os.chdir(config_base_path)
-
     # initialize Survey object
-    survey_2019 = EchoPro.Survey(init_file_path='../config_files/initialization_config.yml',
-                                 survey_year_file_path='../config_files/survey_year_2019_config.yml',
-                                 source=3,
-                                 exclude_age1=True)
+    survey_2019 = EchoPro.Survey(
+        init_file_path=config_base_path / 'initialization_config.yml',
+        survey_year_file_path=config_base_path / 'survey_year_2019_config.yml',
+        source=3,
+        exclude_age1=True
+    )
 
     # load all data
     survey_2019.load_survey_data()
@@ -96,16 +92,13 @@ def test_biomass_age_output(config_base_path, matlab_output_base_path):
 
 
 def test_core_output(config_base_path, matlab_output_base_path):
-
-    # change working directory so no initialization files need to be modified
-    # TODO: this may not be necessary in the future
-    os.chdir(config_base_path)
-
     # initialize Survey object
-    survey_2019 = EchoPro.Survey(init_file_path='../config_files/initialization_config.yml',
-                                 survey_year_file_path='../config_files/survey_year_2019_config.yml',
-                                 source=3,
-                                 exclude_age1=True)
+    survey_2019 = EchoPro.Survey(
+        init_file_path=config_base_path / 'initialization_config.yml',
+        survey_year_file_path=config_base_path / 'survey_year_2019_config.yml',
+        source=3,
+        exclude_age1=True
+    )
 
     # load all data
     survey_2019.load_survey_data()

--- a/EchoPro/tests/length_age/test_length_age.py
+++ b/EchoPro/tests/length_age/test_length_age.py
@@ -1,6 +1,5 @@
 import pytest
 
-import os
 import pandas as pd
 import numpy as np
 import EchoPro
@@ -8,18 +7,15 @@ from EchoPro.computation import SemiVariogram as SV
 
 
 def test_transect_based_length_age(config_base_path, matlab_output_base_path):
-
     # TODO: formalize this test
 
-    # change working directory so no initialization files need to be modified
-    # TODO: this may not be necessary in the future
-    os.chdir(config_base_path)
-
     # initialize Survey object
-    survey_2019 = EchoPro.Survey(init_file_path='../config_files/initialization_config.yml',
-                                 survey_year_file_path='../config_files/survey_year_2019_config.yml',
-                                 source=3,
-                                 exclude_age1=True)
+    survey_2019 = EchoPro.Survey(
+        init_file_path=config_base_path / 'initialization_config.yml',
+        survey_year_file_path=config_base_path / 'survey_year_2019_config.yml',
+        source=3,
+        exclude_age1=True
+    )
 
     # load all data
     survey_2019.load_survey_data()
@@ -80,15 +76,13 @@ def test_transect_based_length_age(config_base_path, matlab_output_base_path):
 def test_kriging_based_length_age(config_base_path, matlab_output_base_path):
     # TODO: formalize this test
 
-    # change working directory so no initialization files need to be modified
-    # TODO: this may not be necessary in the future
-    os.chdir(config_base_path)
-
     # initialize Survey object
-    survey_2019 = EchoPro.Survey(init_file_path='../config_files/initialization_config.yml',
-                                 survey_year_file_path='../config_files/survey_year_2019_config.yml',
-                                 source=3,
-                                 exclude_age1=True)
+    survey_2019 = EchoPro.Survey(
+        init_file_path=config_base_path / 'initialization_config.yml',
+        survey_year_file_path=config_base_path / 'survey_year_2019_config.yml',
+        source=3,
+        exclude_age1=True
+    )
 
     # load all data
     survey_2019.load_survey_data()

--- a/EchoPro/tests/reports/test_reports.py
+++ b/EchoPro/tests/reports/test_reports.py
@@ -25,17 +25,13 @@ def generate_reports(config_base_path: pathlib.Path,
         The base directory path for the reports
     """
 
-    # TODO: should this be put in conftest.py?
-
-    # change working directory so no initialization files need to be modified
-    # TODO: this may not be necessary in the future
-    os.chdir(config_base_path)
-
     # initialize Survey object
-    survey_2019 = EchoPro.Survey(init_file_path='../config_files/initialization_config.yml',
-                                 survey_year_file_path='../config_files/survey_year_2019_config.yml',
-                                 source=3,
-                                 exclude_age1=True)
+    survey_2019 = EchoPro.Survey(
+        init_file_path=config_base_path / 'initialization_config.yml',
+        survey_year_file_path=config_base_path / 'survey_year_2019_config.yml',
+        source=3,
+        exclude_age1=True
+    )
 
     # load all data
     survey_2019.load_survey_data()
@@ -128,7 +124,6 @@ def _compare_truth_produced_files(truth_base_path: pathlib.Path, produced_base_p
     """
 
     for file_ind in range(len(file_names_truth)):
-
         # obtain file_path pointing to the known data
         file_path_truth = truth_base_path / file_names_truth[file_ind]
 
@@ -136,7 +131,6 @@ def _compare_truth_produced_files(truth_base_path: pathlib.Path, produced_base_p
         file_path_produced = produced_base_path / file_names_produced[file_ind]
 
         for sheet_ind in range(len(sheet_names_truth[file_ind])):
-
             # gather known solution data produced by the Matlab version of EchoPro
             df_truth = pd.read_excel(file_path_truth, index_col=index_col_truth[file_ind],
                                      sheet_name=sheet_names_truth[file_ind][sheet_ind],
@@ -171,10 +165,6 @@ def test_length_age_reports(config_base_path: pathlib.Path, matlab_output_base_p
     reports_base_path: pathlib.Path
         The base directory path for the reports
     """
-
-    # change working directory so no initialization files need to be modified
-    # TODO: this may not be necessary in the future
-    os.chdir(config_base_path)
 
     # specify file names
     file_names_truth = ["un-kriged_len_age_abundance_table.xlsx", "kriged_len_age_abundance_table.xlsx",
@@ -221,10 +211,6 @@ def test_biomass_ages_reports(config_base_path: pathlib.Path, matlab_output_base
     reports_base_path: pathlib.Path
         The base directory path for the reports
     """
-
-    # change working directory so no initialization files need to be modified
-    # TODO: this may not be necessary in the future
-    os.chdir(config_base_path)
 
     # specify file names
     file_names_truth = ["EchoPro_un-kriged_aged_output-2019_0.xlsx", "EchoPro_kriged_aged_output-2019_0.xlsx",
@@ -273,10 +259,6 @@ def test_core_variables_reports(config_base_path: pathlib.Path, matlab_output_ba
         The base directory path for the reports
     """
 
-    # change working directory so no initialization files need to be modified
-    # TODO: this may not be necessary in the future
-    os.chdir(config_base_path)
-
     # specify file names
     file_names_truth = ["EchoPro_un-kriged_output-26-Jan-2023_0.xlsx", "EchoPro_kriged_output-26-Jan-2023_0.xlsx",
                         "EchoPro_un-kriged_output-26-Jan-2023_1.xlsx", "EchoPro_kriged_output-26-Jan-2023_1.xlsx"]
@@ -323,10 +305,6 @@ def test_kriging_input_report(config_base_path: pathlib.Path, matlab_output_base
         The base directory path for the reports
     """
 
-    # change working directory so no initialization files need to be modified
-    # TODO: this may not be necessary in the future
-    os.chdir(config_base_path)
-
     # specify file names
     file_names_truth = ["kriging_input.xlsx"]
     file_names_produced = ["kriging_input.xlsx"]
@@ -370,10 +348,6 @@ def test_len_haul_count_reports(config_base_path: pathlib.Path, matlab_output_ba
     reports_base_path: pathlib.Path
         The base directory path for the reports
     """
-
-    # change working directory so no initialization files need to be modified
-    # TODO: this may not be necessary in the future
-    os.chdir(config_base_path)
 
     # specify file names
     file_names_truth = ["aged_len_haul_counts_table.xlsx", "total_len_haul_counts_table.xlsx"]

--- a/EchoPro/tests/transect/test_transect_output.py
+++ b/EchoPro/tests/transect/test_transect_output.py
@@ -1,24 +1,20 @@
 import pytest
 
-import os
 import pandas as pd
 import numpy as np
 import EchoPro
 
 
 def test_biomass_age_output(config_base_path, matlab_output_base_path):
-
     # TODO: formalize this test
 
-    # change working directory so no initialization files need to be modified
-    # TODO: this may not be necessary in the future
-    os.chdir(config_base_path)
-
     # initialize Survey object
-    survey_2019 = EchoPro.Survey(init_file_path='../config_files/initialization_config.yml',
-                                 survey_year_file_path='../config_files/survey_year_2019_config.yml',
-                                 source=3,
-                                 exclude_age1=True)
+    survey_2019 = EchoPro.Survey(
+        init_file_path=config_base_path / 'initialization_config.yml',
+        survey_year_file_path=config_base_path / 'survey_year_2019_config.yml',
+        source=3,
+        exclude_age1=True
+    )
 
     # load all data
     survey_2019.load_survey_data()
@@ -38,27 +34,37 @@ def test_biomass_age_output(config_base_path, matlab_output_base_path):
     sheet_name_female = "Sheet3"
 
     # gather known solution data produced by the Matlab version of EchoPro
-    df_known = pd.read_excel(file_path, sheet_name=sheet_name, skiprows=1, usecols="A:AA").drop(columns=["stratum", "Transect"])
-    male_df_known = pd.read_excel(file_path, sheet_name=sheet_name_male, skiprows=1, usecols="A:AA").drop(
-        columns=["stratum", "Transect"])
-    female_df_known = pd.read_excel(file_path, sheet_name=sheet_name_female, skiprows=1, usecols="A:AA").drop(
-        columns=["stratum", "Transect"])
+    def _read_transform_biomass_age(sheet_name):
+        df = (
+            pd.read_excel(
+                file_path,
+                sheet_name=sheet_name,
+                skiprows=1,
+                usecols="A:AA"
+            )
+            .drop(columns=["stratum", "Transect"])
+            # sort known solution dfs by latitude and longitude
+            .sort_values(by=["Lat", "Lon"])
+        )
+        return df
 
-    # sort known solution dfs by latitude and longitude
-    df_known.sort_values(by=["Lat", "Lon"], inplace=True)
-    male_df_known.sort_values(by=["Lat", "Lon"], inplace=True)
-    female_df_known.sort_values(by=["Lat", "Lon"], inplace=True)
+    df_known = _read_transform_biomass_age(sheet_name)
+    male_df_known = _read_transform_biomass_age(sheet_name_male)
+    female_df_known = _read_transform_biomass_age(sheet_name_female)
 
     # define columns to compare in the produced solution
     produced_wanted_columns = ["latitude", "longitude", "biomass_adult"] + [
         "biomass_age_bin_" + str(i + 1) for i in range(22)]
 
-    df_produced = transect_results.sort_values(by=["latitude",
-                                                   "longitude"])[produced_wanted_columns]
-    male_df_produced = transect_results_male.sort_values(by=["latitude",
-                                                             "longitude"])[produced_wanted_columns]
-    female_df_produced = transect_results_female.sort_values(by=["latitude",
-                                                                 "longitude"])[produced_wanted_columns]
+    df_produced = transect_results.sort_values(
+        by=["latitude", "longitude"]
+    )[produced_wanted_columns]
+    male_df_produced = transect_results_male.sort_values(
+        by=["latitude", "longitude"]
+    )[produced_wanted_columns]
+    female_df_produced = transect_results_female.sort_values(
+        by=["latitude", "longitude"]
+    )[produced_wanted_columns]
 
     # compare known and produced values
     assert np.all(np.isclose(df_known.to_numpy(), df_produced.to_numpy()))
@@ -71,15 +77,13 @@ def test_biomass_age_output(config_base_path, matlab_output_base_path):
 def test_core_output(config_base_path, matlab_output_base_path):
     # TODO: formalize this test
 
-    # change working directory so no initialization files need to be modified
-    # TODO: this may not be necessary in the future
-    os.chdir(config_base_path)
-
     # initialize Survey object
-    survey_2019 = EchoPro.Survey(init_file_path='../config_files/initialization_config.yml',
-                                 survey_year_file_path='../config_files/survey_year_2019_config.yml',
-                                 source=3,
-                                 exclude_age1=True)
+    survey_2019 = EchoPro.Survey(
+        init_file_path=config_base_path / 'initialization_config.yml',
+        survey_year_file_path=config_base_path / 'survey_year_2019_config.yml',
+        source=3,
+        exclude_age1=True
+    )
 
     # load all data
     survey_2019.load_survey_data()


### PR DESCRIPTION
- Add module `_testing.py` that defines pathlib.Path variable `HERE`, for use as a base path primarily in the tests.
- Modified tests to use `HERE` as a basepath instead of the fragile expectations being used, that relied on `os.chdir` and relative paths without a common base path reference.
- Updated test calls to `EchoPro.Survey` to use `config_base_path` instead of relying on a relative path.
- Some code improvements in `test_transect_output.py` to generalize code steps that were being repeated.

Also re-ran all the tests locally, to verify that they all pass.

Contributes to https://github.com/uw-echospace/EchoPro/issues/15#issuecomment-1412665241, building on the earlier PR #80.