### PR TITLE
Fix transect subset selection bug and increment version for new release

### DIFF
--- a/EchoPro/__init__.py
+++ b/EchoPro/__init__.py
@@ -2,5 +2,5 @@ from .survey import Survey
 
 __all__ = ["Survey"]
 
-__version__ = "0.3.0"
+__version__ = "0.3.1"
 


### PR DESCRIPTION
Addresses #95, a bug in the new transect subset selection scheme where "missing" strata were not being handled in the calculation of transect `NASC_adult`. Adds a new test for transect selection and includes some small, cosmetic code tweaks.

The implementation in this PR reverts to the simple, interim scheme being used before this release, described in #33. An implementation that reflects the Matlab implementation more faithfully will be addressed in the next release.

Also increments the version to 0.3.1 in preparation for the new release.