### PR TITLE
Simplify input file reading and checking

### DIFF
--- a/EchoPro/data_loader/biological_data.py
+++ b/EchoPro/data_loader/biological_data.py
@@ -231,6 +231,34 @@ class LoadBioData:  # TODO: Does it make sense for this to be a class?
 
         return df
 
+    def _check_and_read(self, param_filename: str, param_sheetname: str, cols_types: dict):
+        """
+        For input data table, check file path and column names, and read into DataFrame.
+
+        Parameters
+        ----------
+        param_filename : str
+            Name of configuration parameter specifying the file path
+        param_sheetname : str
+            Name of configuration parameter specifying the Excel file sheet name
+        cols_types : dict
+            Dictionary specifying the column names and types for the target input data
+
+        Returns
+        -------
+        pd.DataFrame
+            Read and checked Dataframe
+        """
+        # check existence of the files
+        file_path = self.survey.params["data_root_dir"] / self.survey.params[param_filename]
+        check_existence_of_file(file_path)
+
+        # read in and check Excel file
+        df = pd.read_excel(file_path, sheet_name=self.survey.params[param_sheetname])
+        check_column_names(df=df, expected_names=set(cols_types.keys()), path_for_df=file_path)
+
+        return df
+
     def _load_length_data(self) -> None:
         """
         Loads and prepares data associated with a station
@@ -240,36 +268,16 @@ class LoadBioData:  # TODO: Does it make sense for this to be a class?
         """
 
         if self.survey.params["source"] == 3:
-
-            # check existence of the files
-            file_path_us = (
-                self.survey.params["data_root_dir"]
-                / self.survey.params["length_US_filename"]
-            )
-            file_path_can = (
-                self.survey.params["data_root_dir"]
-                / self.survey.params["length_CAN_filename"]
-            )
-            check_existence_of_file(file_path_us)
-            check_existence_of_file(file_path_can)
-
-            # read in and check US and Canada Excel files
-            df_us = pd.read_excel(
-                file_path_us, sheet_name=self.survey.params["length_US_sheet"]
-            )
-            check_column_names(
-                df=df_us,
-                expected_names=set(self.len_cols_types.keys()),
-                path_for_df=file_path_us
+            df_us = self._check_and_read(
+                "length_US_filename",
+                "length_US_sheet",
+                self.len_cols_types
             )
 
-            df_can = pd.read_excel(
-                file_path_can, sheet_name=self.survey.params["length_CAN_sheet"]
-            )
-            check_column_names(
-                df=df_can,
-                expected_names=set(self.len_cols_types.keys()),
-                path_for_df=file_path_can
+            df_can = self._check_and_read(
+                "length_CAN_filename",
+                "length_CAN_sheet",
+                self.len_cols_types
             )
 
             # process US and Canada dataframes
@@ -280,7 +288,6 @@ class LoadBioData:  # TODO: Does it make sense for this to be a class?
 
             # Construct full length dataframe from US and Canada sections
             self.survey.length_df = pd.concat([length_us_df, length_can_df])
-
         else:
             raise NotImplementedError(
                 f"Source of {self.survey.params['source']} not implemented yet."
@@ -295,47 +302,26 @@ class LoadBioData:  # TODO: Does it make sense for this to be a class?
         """
 
         if self.survey.params["source"] == 3:
-
-            # check existence of the files
-            file_path_us = (
-                self.survey.params["data_root_dir"]
-                / self.survey.params["specimen_US_filename"]
-            )
-            file_path_can = (
-                self.survey.params["data_root_dir"]
-                / self.survey.params["specimen_CAN_filename"]
-            )
-            check_existence_of_file(file_path_us)
-            check_existence_of_file(file_path_can)
-
-            # read in and check US and Canada Excel files
-            specimen_us_df = pd.read_excel(
-                file_path_us, sheet_name=self.survey.params["specimen_US_sheet"]
-            )
-            check_column_names(
-                df=specimen_us_df,
-                expected_names=set(self.spec_cols_types.keys()),
-                path_for_df=file_path_us
+            df_us = self._check_and_read(
+                "specimen_US_filename",
+                "specimen_US_sheet",
+                self.spec_cols_types
             )
 
-            specimen_can_df = pd.read_excel(
-                file_path_can, sheet_name=self.survey.params["specimen_CAN_sheet"]
-            )
-            check_column_names(
-                df=specimen_can_df,
-                expected_names=set(self.spec_cols_types.keys()),
-                path_for_df=file_path_can
+            df_can = self._check_and_read(
+                "specimen_CAN_filename",
+                "specimen_CAN_sheet",
+                self.spec_cols_types
             )
 
             # process US and Canada dataframes
-            specimen_us_df = self._process_specimen_data(specimen_us_df, 0)
+            specimen_us_df = self._process_specimen_data(df_us, 0)
             specimen_can_df = self._process_specimen_data(
-                specimen_can_df, self.survey.params["CAN_haul_offset"]
+                df_can, self.survey.params["CAN_haul_offset"]
             )
 
             # Construct full specimen dataframe from US and Canada sections
             self.survey.specimen_df = pd.concat([specimen_us_df, specimen_can_df])
-
         else:
             raise NotImplementedError(
                 f"Source of {self.survey.params['source']} not implemented yet."
@@ -350,47 +336,26 @@ class LoadBioData:  # TODO: Does it make sense for this to be a class?
         """
 
         if self.survey.params["source"] == 3:
-
-            # check existence of the files
-            file_path_us = (
-                self.survey.params["data_root_dir"]
-                / self.survey.params["catch_US_filename"]
-            )
-            file_path_can = (
-                self.survey.params["data_root_dir"]
-                / self.survey.params["catch_CAN_filename"]
-            )
-            check_existence_of_file(file_path_us)
-            check_existence_of_file(file_path_can)
-
-            # read in and check US and Canada Excel files
-            catch_us_df = pd.read_excel(
-                file_path_us, sheet_name=self.survey.params["catch_US_sheet"]
-            )
-            check_column_names(
-                df=catch_us_df,
-                expected_names=set(self.catch_cols_types.keys()),
-                path_for_df=file_path_us
+            df_us = self._check_and_read(
+                "catch_US_filename",
+                "catch_US_sheet",
+                self.catch_cols_types
             )
 
-            catch_can_df = pd.read_excel(
-                file_path_can, sheet_name=self.survey.params["catch_CAN_sheet"]
-            )
-            check_column_names(
-                df=catch_can_df,
-                expected_names=set(self.catch_cols_types.keys()),
-                path_for_df=file_path_can
+            df_can = self._check_and_read(
+                "catch_CAN_filename",
+                "catch_CAN_sheet",
+                self.catch_cols_types
             )
 
             # process US and Canada dataframes
-            catch_us_df = self._process_catch_data(catch_us_df, 0)
+            catch_us_df = self._process_catch_data(df_us, 0)
             catch_can_df = self._process_catch_data(
-                catch_can_df, self.survey.params["CAN_haul_offset"]
+                df_can, self.survey.params["CAN_haul_offset"]
             )
 
             # Construct full catch dataframe from US and Canada sections
             self.survey.catch_df = pd.concat([catch_us_df, catch_can_df])
-
         else:
 
             raise NotImplementedError(
@@ -409,50 +374,20 @@ class LoadBioData:  # TODO: Does it make sense for this to be a class?
         """
 
         if self.survey.params["source"] == 3:
-
-            # check existence of the files
-            file_path_us = (
-                self.survey.params["data_root_dir"]
-                / self.survey.params["filename_haul_to_transect_US"]
-            )
-            file_path_can = (
-                self.survey.params["data_root_dir"]
-                / self.survey.params["filename_haul_to_transect_CAN"]
-            )
-            check_existence_of_file(file_path_us)
-            check_existence_of_file(file_path_can)
-
-            # read in, check, and process the US haul to transect mapping file
-            haul_to_transect_mapping_us_df = pd.read_excel(
-                file_path_us,
-                sheet_name=self.survey.params["haul_to_transect_US_sheetname"],
-            )
-            check_column_names(
-                df=haul_to_transect_mapping_us_df,
-                expected_names=set(self.haul_to_transect_mapping_cols_types.keys()),
-                path_for_df=file_path_us,
-            )
-            haul_to_transect_mapping_us_df = (
-                self._process_haul_to_transect_mapping_data(
-                    haul_to_transect_mapping_us_df
-                )
+            df_us = self._check_and_read(
+                "filename_haul_to_transect_US",
+                "haul_to_transect_US_sheetname",
+                self.haul_to_transect_mapping_cols_types
             )
 
-            # read in, check, and process the Canada haul to transect mapping file
-            haul_to_transect_mapping_can_df = pd.read_excel(
-                file_path_can,
-                sheet_name=self.survey.params["haul_to_transect_CAN_sheetname"],
+            df_can = self._check_and_read(
+                "filename_haul_to_transect_CAN",
+                "haul_to_transect_CAN_sheetname",
+                self.haul_to_transect_mapping_cols_types
             )
-            check_column_names(
-                df=haul_to_transect_mapping_can_df,
-                expected_names=set(self.haul_to_transect_mapping_cols_types.keys()),
-                path_for_df=file_path_can,
-            )
-            haul_to_transect_mapping_can_df = (
-                self._process_haul_to_transect_mapping_data(
-                    haul_to_transect_mapping_can_df
-                )
-            )
+
+            haul_to_transect_mapping_us_df = self._process_haul_to_transect_mapping_data(df_us)
+            haul_to_transect_mapping_can_df = self._process_haul_to_transect_mapping_data(df_can)
 
             # transect offset is set to zero since we will not have overlapping transects
             # TODO: Is this a necessary variable? If so, we should make it an input to the function.
@@ -471,7 +406,6 @@ class LoadBioData:  # TODO: Does it make sense for this to be a class?
             self.survey.haul_to_transect_mapping_df = pd.concat(
                 [haul_to_transect_mapping_us_df, haul_to_transect_mapping_can_df]
             )
-
         else:
             raise NotImplementedError(
                 f"Source of {self.survey.params['source']} not implemented yet."

--- a/EchoPro/data_loader/biological_data.py
+++ b/EchoPro/data_loader/biological_data.py
@@ -23,16 +23,34 @@ class LoadBioData:  # TODO: Does it make sense for this to be a class?
         self.survey = survey
 
         # expected columns for length Dataframe
-        self.len_cols = {"haul_num", "species_id", "sex", "length", "length_count"}
+        self.len_cols_types = {
+            "haul_num": int,
+            "species_id": int,
+            "sex": int,
+            "length": np.float64,
+            "length_count": np.float64,
+        }
 
         # expected columns for specimen Dataframe
-        self.spec_cols = {"haul_num", "species_id", "sex", "length", "weight", "age"}
+        self.spec_cols_types = {
+            "haul_num": int,
+            "species_id": int,
+            "sex": int,
+            "length": np.float64,
+            "weight": np.float64,
+            "age": np.float64,
+        }
 
         # expected columns for catch Dataframe
-        self.catch_cols = {"haul_num", "species_id", "haul_count", "haul_weight"}
+        self.catch_cols_types = {
+            "haul_num": int,
+            "species_id": int,
+            "haul_count": np.float64,
+            "haul_weight": np.float64,
+        }
 
         # expected columns for haul_to_transect_mapping Dataframe
-        self.haul_to_transect_mapping_cols = {"haul_num", "transect_num"}
+        self.haul_to_transect_mapping_cols_types = {"haul_num": int, "transect_num": np.float64}
 
         self._load_length_data()
         self._load_specimen_data()
@@ -63,18 +81,10 @@ class LoadBioData:  # TODO: Does it make sense for this to be a class?
         """
 
         # obtaining those columns that are required
-        df = df[["haul_num", "species_id", "sex", "length", "length_count"]].copy()
+        df = df[list(self.len_cols_types.keys())].copy()
 
         # set data types of dataframe
-        df = df.astype(
-            {
-                "haul_num": int,
-                "species_id": int,
-                "sex": int,
-                "length": np.float64,
-                "length_count": np.float64,
-            }
-        )
+        df = df.astype(self.len_cols_types)
 
         # extract target species
         df = df.loc[df["species_id"] == self.survey.params["species_id"]]
@@ -116,19 +126,10 @@ class LoadBioData:  # TODO: Does it make sense for this to be a class?
         """
 
         # obtaining those columns that are required
-        df = df[["haul_num", "species_id", "sex", "length", "weight", "age"]].copy()
+        df = df[list(self.spec_cols_types.keys())].copy()
 
         # set data types of dataframe
-        df = df.astype(
-            {
-                "haul_num": int,
-                "species_id": int,
-                "sex": int,
-                "length": np.float64,
-                "weight": np.float64,
-                "age": np.float64,
-            }
-        )
+        df = df.astype(self.spec_cols_types)
 
         # extract target species
         df = df.loc[df["species_id"] == self.survey.params["species_id"]]
@@ -176,17 +177,10 @@ class LoadBioData:  # TODO: Does it make sense for this to be a class?
         """
 
         # obtaining those columns that are required
-        df = df[["haul_num", "species_id", "haul_count", "haul_weight"]].copy()
+        df = df[list(self.catch_cols_types.keys())].copy()
 
         # set data types of dataframe
-        df = df.astype(
-            {
-                "haul_num": int,
-                "species_id": int,
-                "haul_count": np.float64,
-                "haul_weight": np.float64,
-            }
-        )
+        df = df.astype(self.catch_cols_types)
 
         # extract target species
         df = df.loc[df["species_id"] == self.survey.params["species_id"]]
@@ -229,12 +223,20 @@ class LoadBioData:  # TODO: Does it make sense for this to be a class?
             df_us = pd.read_excel(
                 file_path_us, sheet_name=self.survey.params["length_US_sheet"]
             )
-            check_column_names(df=df_us, expected_names=self.len_cols, path_for_df=file_path_us)
+            check_column_names(
+                df=df_us,
+                expected_names=set(self.len_cols_types.keys()),
+                path_for_df=file_path_us
+            )
 
             df_can = pd.read_excel(
                 file_path_can, sheet_name=self.survey.params["length_CAN_sheet"]
             )
-            check_column_names(df=df_can, expected_names=self.len_cols, path_for_df=file_path_can)
+            check_column_names(
+                df=df_can,
+                expected_names=set(self.len_cols_types.keys()),
+                path_for_df=file_path_can
+            )
 
             # process US and Canada dataframes
             length_us_df = self._process_length_data_df(df_us, 0)
@@ -277,14 +279,18 @@ class LoadBioData:  # TODO: Does it make sense for this to be a class?
                 file_path_us, sheet_name=self.survey.params["specimen_US_sheet"]
             )
             check_column_names(
-                df=specimen_us_df, expected_names=self.spec_cols, path_for_df=file_path_us
+                df=specimen_us_df,
+                expected_names=set(self.spec_cols_types.keys()),
+                path_for_df=file_path_us
             )
 
             specimen_can_df = pd.read_excel(
                 file_path_can, sheet_name=self.survey.params["specimen_CAN_sheet"]
             )
             check_column_names(
-                df=specimen_can_df, expected_names=self.spec_cols, path_for_df=file_path_can
+                df=specimen_can_df,
+                expected_names=set(self.spec_cols_types.keys()),
+                path_for_df=file_path_can
             )
 
             # process US and Canada dataframes
@@ -328,14 +334,18 @@ class LoadBioData:  # TODO: Does it make sense for this to be a class?
                 file_path_us, sheet_name=self.survey.params["catch_US_sheet"]
             )
             check_column_names(
-                df=catch_us_df, expected_names=self.catch_cols, path_for_df=file_path_us
+                df=catch_us_df,
+                expected_names=set(self.catch_cols_types.keys()),
+                path_for_df=file_path_us
             )
 
             catch_can_df = pd.read_excel(
                 file_path_can, sheet_name=self.survey.params["catch_CAN_sheet"]
             )
             check_column_names(
-                df=catch_can_df, expected_names=self.catch_cols, path_for_df=file_path_can
+                df=catch_can_df,
+                expected_names=set(self.catch_cols_types.keys()),
+                path_for_df=file_path_can
             )
 
             # process US and Canada dataframes
@@ -373,10 +383,10 @@ class LoadBioData:  # TODO: Does it make sense for this to be a class?
         """
 
         # obtain those columns necessary for core downstream processes
-        df = df[["haul_num", "transect_num"]].copy()
+        df = df[list(self.haul_to_transect_mapping_cols_types.keys())].copy()
 
         # set data types of dataframe
-        df = df.astype({"haul_num": int, "transect_num": np.float64})
+        df = df.astype(self.haul_to_transect_mapping_cols_types)
 
         if self.survey.params["exclude_age1"] is False:
             raise NotImplementedError("Including age 1 data has not been implemented!")
@@ -419,7 +429,7 @@ class LoadBioData:  # TODO: Does it make sense for this to be a class?
             )
             check_column_names(
                 df=haul_to_transect_mapping_us_df,
-                expected_names=self.haul_to_transect_mapping_cols,
+                expected_names=set(self.haul_to_transect_mapping_cols_types.keys()),
                 path_for_df=file_path_us,
             )
             haul_to_transect_mapping_us_df = (
@@ -435,7 +445,7 @@ class LoadBioData:  # TODO: Does it make sense for this to be a class?
             )
             check_column_names(
                 df=haul_to_transect_mapping_can_df,
-                expected_names=self.haul_to_transect_mapping_cols,
+                expected_names=set(self.haul_to_transect_mapping_cols_types.keys()),
                 path_for_df=file_path_can,
             )
             haul_to_transect_mapping_can_df = (

--- a/EchoPro/data_loader/biological_data.py
+++ b/EchoPro/data_loader/biological_data.py
@@ -39,84 +39,6 @@ class LoadBioData:  # TODO: Does it make sense for this to be a class?
         self._load_catch_data()
         self._load_haul_to_transect_mapping_data()
 
-    def _check_length_df(self, len_df: pd.DataFrame, df_path: Path) -> None:
-        """
-        Ensures that the appropriate columns are
-        contained in the length Dataframe.
-
-        Parameters
-        ----------
-        len_df: pd.DataFrame
-            The constructed Length DataFrame
-        df_path: Path
-            The path to the Excel file used to construct the DataFrame
-        """
-
-        # TODO: should we add more in-depth checks here?
-
-        check_column_names(df=len_df, expected_names=self.len_cols, path_for_df=df_path)
-
-    def _check_specimen_df(self, spec_df: pd.DataFrame, df_path: Path) -> None:
-        """
-        Ensures that the appropriate columns are
-        contained in the specimen Dataframe.
-
-        Parameters
-        ----------
-        spec_df: pd.DataFrame
-            The constructed Specimen DataFrame
-        df_path: Path
-            The path to the Excel file used to construct the DataFrame
-        """
-
-        # TODO: should we add more in-depth checks here?
-
-        check_column_names(
-            df=spec_df, expected_names=self.spec_cols, path_for_df=df_path
-        )
-
-    def _check_catch_df(self, catch_df: pd.DataFrame, df_path: Path) -> None:
-        """
-        Ensures that the appropriate columns are
-        contained in the Catch Dataframe.
-
-        Parameters
-        ----------
-        catch_df: pd.DataFrame
-            The constructed Catch DataFrame
-        df_path: Path
-            The path to the Excel file used to construct the DataFrame
-        """
-
-        # TODO: should we add more in-depth checks here?
-
-        check_column_names(
-            df=catch_df, expected_names=self.catch_cols, path_for_df=df_path
-        )
-
-    def _check_haul_to_transect_mapping_df(
-        self, haul_to_transect_mapping_df: pd.DataFrame, df_path: Path
-    ) -> None:
-        """
-        Ensures that the appropriate columns are
-        contained in the haul to transect mapping Dataframe.
-
-        Parameters
-        ----------
-        haul_to_transect_mapping_df: pd.DataFrame
-            The constructed haul to transect mapping DataFrame
-        df_path: Path
-            The path to the Excel file used to construct the DataFrame
-        """
-
-        # TODO: should we add more in-depth checks here?
-
-        check_column_names(
-            df=haul_to_transect_mapping_df,
-            expected_names=self.haul_to_transect_mapping_cols,
-            path_for_df=df_path,
-        )
-
     def _process_length_data_df(
         self, df: pd.DataFrame, haul_num_offset: int
     ) -> pd.DataFrame:
@@ -307,12 +229,12 @@ class LoadBioData:  # TODO: Does it make sense for this to be a class?
             df_us = pd.read_excel(
                 file_path_us, sheet_name=self.survey.params["length_US_sheet"]
             )
-            self._check_length_df(df_us, file_path_us)
+            check_column_names(df=df_us, expected_names=self.len_cols, path_for_df=file_path_us)
 
             df_can = pd.read_excel(
                 file_path_can, sheet_name=self.survey.params["length_CAN_sheet"]
             )
-            self._check_length_df(df_can, file_path_can)
+            check_column_names(df=df_can, expected_names=self.len_cols, path_for_df=file_path_can)
 
             # process US and Canada dataframes
             length_us_df = self._process_length_data_df(df_us, 0)
@@ -354,12 +276,16 @@ class LoadBioData:  # TODO: Does it make sense for this to be a class?
             specimen_us_df = pd.read_excel(
                 file_path_us, sheet_name=self.survey.params["specimen_US_sheet"]
             )
-            self._check_specimen_df(specimen_us_df, file_path_us)
+            check_column_names(
+                df=specimen_us_df, expected_names=self.spec_cols, path_for_df=file_path_us
+            )
 
             specimen_can_df = pd.read_excel(
                 file_path_can, sheet_name=self.survey.params["specimen_CAN_sheet"]
             )
-            self._check_specimen_df(specimen_can_df, file_path_can)
+            check_column_names(
+                df=specimen_can_df, expected_names=self.spec_cols, path_for_df=file_path_can
+            )
 
             # process US and Canada dataframes
             specimen_us_df = self._process_specimen_data(specimen_us_df, 0)
@@ -401,12 +327,16 @@ class LoadBioData:  # TODO: Does it make sense for this to be a class?
             catch_us_df = pd.read_excel(
                 file_path_us, sheet_name=self.survey.params["catch_US_sheet"]
             )
-            self._check_catch_df(catch_us_df, file_path_us)
+            check_column_names(
+                df=catch_us_df, expected_names=self.catch_cols, path_for_df=file_path_us
+            )
 
             catch_can_df = pd.read_excel(
                 file_path_can, sheet_name=self.survey.params["catch_CAN_sheet"]
             )
-            self._check_catch_df(catch_can_df, file_path_can)
+            check_column_names(
+                df=catch_can_df, expected_names=self.catch_cols, path_for_df=file_path_can
+            )
 
             # process US and Canada dataframes
             catch_us_df = self._process_catch_data(catch_us_df, 0)
@@ -487,8 +417,10 @@ class LoadBioData:  # TODO: Does it make sense for this to be a class?
                 file_path_us,
                 sheet_name=self.survey.params["haul_to_transect_US_sheetname"],
             )
-            self._check_haul_to_transect_mapping_df(
-                haul_to_transect_mapping_us_df, file_path_us
+            check_column_names(
+                df=haul_to_transect_mapping_us_df,
+                expected_names=self.haul_to_transect_mapping_cols,
+                path_for_df=file_path_us,
             )
             haul_to_transect_mapping_us_df = (
                 self._process_haul_to_transect_mapping_data(
@@ -501,8 +433,10 @@ class LoadBioData:  # TODO: Does it make sense for this to be a class?
                 file_path_can,
                 sheet_name=self.survey.params["haul_to_transect_CAN_sheetname"],
             )
-            self._check_haul_to_transect_mapping_df(
-                haul_to_transect_mapping_can_df, file_path_can
+            check_column_names(
+                df=haul_to_transect_mapping_can_df,
+                expected_names=self.haul_to_transect_mapping_cols,
+                path_for_df=file_path_can,
             )
             haul_to_transect_mapping_can_df = (
                 self._process_haul_to_transect_mapping_data(

--- a/EchoPro/data_loader/biological_data.py
+++ b/EchoPro/data_loader/biological_data.py
@@ -197,6 +197,40 @@ class LoadBioData:  # TODO: Does it make sense for this to be a class?
 
         return df
 
+    def _process_haul_to_transect_mapping_data(self, df: pd.DataFrame) -> pd.DataFrame:
+        """
+        Processes the haul to transect mapping data by
+        * selecting the haul and transect columns
+        * ensuring the dataframe has the appropriate data types
+        * setting the ``haul_num`` column as the Dataframe index
+        * sorting the ``haul_num`` index in ascending order
+
+        Parameters
+        ----------
+        df : pd. Dataframe
+            Dataframe holding the haul to transect mapping data
+
+        Returns
+        -------
+        pd.DataFrame
+            Processed haul to transect mapping Dataframe
+        """
+
+        # obtain those columns necessary for core downstream processes
+        df = df[list(self.haul_to_transect_mapping_cols_types.keys())].copy()
+
+        # set data types of dataframe
+        df = df.astype(self.haul_to_transect_mapping_cols_types)
+
+        if self.survey.params["exclude_age1"] is False:
+            raise NotImplementedError("Including age 1 data has not been implemented!")
+
+        # set haul_num as index and sort it
+        df.set_index("haul_num", inplace=True)
+        df.sort_index(inplace=True)
+
+        return df
+
     def _load_length_data(self) -> None:
         """
         Loads and prepares data associated with a station
@@ -362,40 +396,6 @@ class LoadBioData:  # TODO: Does it make sense for this to be a class?
             raise NotImplementedError(
                 f"Source of {self.survey.params['source']} not implemented yet."
             )
-
-    def _process_haul_to_transect_mapping_data(self, df: pd.DataFrame) -> pd.DataFrame:
-        """
-        Processes the haul to transect mapping data by
-        * selecting the haul and transect columns
-        * ensuring the dataframe has the appropriate data types
-        * setting the ``haul_num`` column as the Dataframe index
-        * sorting the ``haul_num`` index in ascending order
-
-        Parameters
-        ----------
-        df : pd. Dataframe
-            Dataframe holding the haul to transect mapping data
-
-        Returns
-        -------
-        pd.DataFrame
-            Processed haul to transect mapping Dataframe
-        """
-
-        # obtain those columns necessary for core downstream processes
-        df = df[list(self.haul_to_transect_mapping_cols_types.keys())].copy()
-
-        # set data types of dataframe
-        df = df.astype(self.haul_to_transect_mapping_cols_types)
-
-        if self.survey.params["exclude_age1"] is False:
-            raise NotImplementedError("Including age 1 data has not been implemented!")
-
-        # set haul_num as index and sort it
-        df.set_index("haul_num", inplace=True)
-        df.sort_index(inplace=True)
-
-        return df
 
     def _load_haul_to_transect_mapping_data(self) -> None:
         """

--- a/EchoPro/data_loader/kriging_mesh.py
+++ b/EchoPro/data_loader/kriging_mesh.py
@@ -1,4 +1,3 @@
-from pathlib import Path
 from typing import Tuple, Union
 
 import geopandas as gpd
@@ -8,7 +7,7 @@ from scipy import interpolate
 from shapely.geometry import Polygon
 from shapely.ops import unary_union
 
-from ..utils.input_checks import check_column_names, check_existence_of_file
+from ..utils.input_checks_read import check_and_read
 
 
 class KrigingMesh:
@@ -60,24 +59,12 @@ class KrigingMesh:
         the full mesh and assigns it as the class variable ``mesh_gdf``.
         """
 
-        # check existence of the file
-        file_path = (
-            self.survey.params["data_root_dir"] / self.survey.params["mesh_filename"]
+        df = check_and_read(
+            "mesh_filename",
+            "mesh_sheetname",
+            self.mesh_cols_types,
+            self.survey.params
         )
-        check_existence_of_file(file_path)
-
-        df = pd.read_excel(file_path, sheet_name=self.survey.params["mesh_sheetname"])
-        check_column_names(
-            df=df,
-            expected_names=set(self.mesh_cols_types.keys()),
-            path_for_df=file_path
-        )
-
-        # obtaining those columns that are required
-        df = df[list(self.mesh_cols_types.keys())].copy()
-
-        # set data types of dataframe
-        df = df.astype(self.mesh_cols_types)
 
         # construct geopandas DataFrame to simplify downstream processes
         gdf = gpd.GeoDataFrame(
@@ -100,27 +87,12 @@ class KrigingMesh:
         ``smoothed_contour_gdf``.
         """
 
-        # check existence of the file
-        file_path = (
-            self.survey.params["data_root_dir"]
-            / self.survey.params["smoothed_contour_filename"]
+        df = check_and_read(
+            "smoothed_contour_filename",
+            "smoothed_contour_sheetname",
+            self.contour_cols_types,
+            self.survey.params
         )
-        check_existence_of_file(file_path)
-
-        df = pd.read_excel(
-            file_path, sheet_name=self.survey.params["smoothed_contour_sheetname"]
-        )
-        check_column_names(
-            df=df,
-            expected_names=set(self.contour_cols_types.keys()),
-            path_for_df=file_path
-        )
-
-        # obtaining those columns that are required
-        df = df[list(self.contour_cols_types.keys())].copy()
-
-        # set data types of dataframe
-        df = df.astype(self.contour_cols_types)
 
         # construct geopandas DataFrame to simplify downstream processes
         df = gpd.GeoDataFrame(

--- a/EchoPro/data_loader/kriging_mesh.py
+++ b/EchoPro/data_loader/kriging_mesh.py
@@ -33,14 +33,14 @@ class KrigingMesh:
         self.survey = survey
 
         # expected columns for the mesh Dataframe
-        self.mesh_cols = {
-            "centroid_latitude",
-            "centroid_longitude",
-            "fraction_cell_in_polygon",
+        self.mesh_cols_types = {
+            "centroid_latitude": float,
+            "centroid_longitude": float,
+            "fraction_cell_in_polygon": np.float64,
         }
 
         # expected columns for the smoothed contour Dataframe
-        self.contour_cols = {"latitude", "longitude"}
+        self.contour_cols_types = {"latitude": float, "longitude": float}
 
         # initialize mesh parameters
         self.transformed_transect_df = None
@@ -67,21 +67,17 @@ class KrigingMesh:
         check_existence_of_file(file_path)
 
         df = pd.read_excel(file_path, sheet_name=self.survey.params["mesh_sheetname"])
-        check_column_names(df=df, expected_names=self.mesh_cols, path_for_df=file_path)
+        check_column_names(
+            df=df,
+            expected_names=set(self.mesh_cols_types.keys()),
+            path_for_df=file_path
+        )
 
         # obtaining those columns that are required
-        df = df[
-            ["centroid_latitude", "centroid_longitude", "fraction_cell_in_polygon"]
-        ].copy()
+        df = df[list(self.mesh_cols_types.keys())].copy()
 
         # set data types of dataframe
-        df = df.astype(
-            {
-                "centroid_latitude": float,
-                "centroid_longitude": float,
-                "fraction_cell_in_polygon": np.float64,
-            }
-        )
+        df = df.astype(self.mesh_cols_types)
 
         # construct geopandas DataFrame to simplify downstream processes
         gdf = gpd.GeoDataFrame(
@@ -114,13 +110,17 @@ class KrigingMesh:
         df = pd.read_excel(
             file_path, sheet_name=self.survey.params["smoothed_contour_sheetname"]
         )
-        check_column_names(df=df, expected_names=self.contour_cols, path_for_df=file_path)
+        check_column_names(
+            df=df,
+            expected_names=set(self.contour_cols_types.keys()),
+            path_for_df=file_path
+        )
 
         # obtaining those columns that are required
-        df = df[["latitude", "longitude"]].copy()
+        df = df[list(self.contour_cols_types.keys())].copy()
 
         # set data types of dataframe
-        df = df.astype({"latitude": float, "longitude": float})
+        df = df.astype(self.contour_cols_types)
 
         # construct geopandas DataFrame to simplify downstream processes
         df = gpd.GeoDataFrame(

--- a/EchoPro/data_loader/kriging_mesh.py
+++ b/EchoPro/data_loader/kriging_mesh.py
@@ -51,46 +51,6 @@ class KrigingMesh:
         self._load_mesh()
         self._load_smoothed_contour()
 
-    def _check_mesh_df(self, mesh_df: pd.DataFrame, df_path: Path) -> None:
-        """
-        Ensures that the appropriate columns are
-        contained in the mesh Dataframe.
-
-        Parameters
-        ----------
-        mesh_df: pd.DataFrame
-            The constructed Mesh DataFrame
-        df_path: Path
-            The path to the Excel file used to construct the DataFrame
-        """
-
-        # TODO: should we add more in-depth checks here?
-
-        check_column_names(
-            df=mesh_df, expected_names=self.mesh_cols, path_for_df=df_path
-        )
-
-    def _check_smoothed_contour_df(
-        self, contour_df: pd.DataFrame, df_path: Path
-    ) -> None:
-        """
-        Ensures that the appropriate columns are
-        contained in the smoothed contour Dataframe.
-
-        Parameters
-        ----------
-        contour_df: pd.DataFrame
-            The constructed Contour DataFrame
-        df_path: Path
-            The path to the Excel file used to construct the DataFrame
-        """
-
-        # TODO: should we add more in-depth checks here?
-
-        check_column_names(
-            df=contour_df, expected_names=self.contour_cols, path_for_df=df_path
-        )
-
     def _load_mesh(self) -> None:
         """
         Loads the full mesh of the region being considered.
@@ -107,7 +67,7 @@ class KrigingMesh:
         check_existence_of_file(file_path)
 
         df = pd.read_excel(file_path, sheet_name=self.survey.params["mesh_sheetname"])
-        self._check_mesh_df(df, file_path)
+        check_column_names(df=df, expected_names=self.mesh_cols, path_for_df=file_path)
 
         # obtaining those columns that are required
         df = df[
@@ -154,7 +114,7 @@ class KrigingMesh:
         df = pd.read_excel(
             file_path, sheet_name=self.survey.params["smoothed_contour_sheetname"]
         )
-        self._check_smoothed_contour_df(df, file_path)
+        check_column_names(df=df, expected_names=self.contour_cols, path_for_df=file_path)
 
         # obtaining those columns that are required
         df = df[["latitude", "longitude"]].copy()

--- a/EchoPro/data_loader/nasc_data.py
+++ b/EchoPro/data_loader/nasc_data.py
@@ -1,10 +1,7 @@
-from pathlib import Path
-from typing import Set
-
 import numpy as np
 import pandas as pd
 
-from ..utils.input_checks import check_column_names, check_existence_of_file
+from ..utils.input_checks_read import check_and_read
 
 
 def _process_nasc_data(survey, nasc_var_types: dict) -> pd.DataFrame:
@@ -29,33 +26,19 @@ def _process_nasc_data(survey, nasc_var_types: dict) -> pd.DataFrame:
 
     # select and check the appropriate nasc data file
     if survey.params["exclude_age1"]:
-        # check existence of the file
-        file_path = (
-            survey.params["data_root_dir"] / survey.params["nasc_no_age1_filename"]
-        )
-        check_existence_of_file(file_path)
-
-        df = pd.read_excel(
-            file_path, sheet_name=survey.params["nasc_no_age1_sheetname"]
+        df = check_and_read(
+            "nasc_no_age1_filename",
+            "nasc_no_age1_sheetname",
+            nasc_var_types,
+            survey.params
         )
     else:
-        # check existence of the file
-        file_path = (
-            survey.params["data_root_dir"] / survey.params["nasc_all_ages_filename"]
+        df = check_and_read(
+            "nasc_all_ages_filename",
+            "nasc_all_ages_sheetname",
+            nasc_var_types,
+            survey.params
         )
-        check_existence_of_file(file_path)
-
-        df = pd.read_excel(
-            file_path, sheet_name=survey.params["nasc_all_ages_sheetname"]
-        )
-
-    check_column_names(df=df, expected_names=set(nasc_var_types.keys()), path_for_df=file_path)
-
-    # obtaining those columns that are required
-    df = df[nasc_var_types.keys()]
-
-    # set data types of dataframe
-    df = df.astype(nasc_var_types)
 
     if survey.params["survey_year"] < 2003:
         # TODO: it may be the case that we need to include lines 35-61 of

--- a/EchoPro/data_loader/nasc_data.py
+++ b/EchoPro/data_loader/nasc_data.py
@@ -7,26 +7,6 @@ import pandas as pd
 from ..utils.input_checks import check_column_names, check_existence_of_file
 
 
-def _check_nasc_df(nasc_df: pd.DataFrame, df_path: Path, nasc_cols: Set[str]) -> None:
-    """
-    Ensures that the appropriate columns are
-    contained in the NASC Dataframe.
-
-    Parameters
-    ----------
-    nasc_df: pd.DataFrame
-        The constructed NASC DataFrame
-    df_path: Path
-        The path to the Excel file used to construct the DataFrame
-    nasc_cols: set of str
-        A set of strings specifying the NASC columns to grab
-    """
-
-    # TODO: should we add more in-depth checks here?
-
-    check_column_names(df=nasc_df, expected_names=nasc_cols, path_for_df=df_path)
-
-
 def _process_nasc_data(survey, nasc_var_types: dict) -> pd.DataFrame:
     """
     Loads in NASC data from the appropriate Excel file using the
@@ -49,7 +29,6 @@ def _process_nasc_data(survey, nasc_var_types: dict) -> pd.DataFrame:
 
     # select and check the appropriate nasc data file
     if survey.params["exclude_age1"]:
-
         # check existence of the file
         file_path = (
             survey.params["data_root_dir"] / survey.params["nasc_no_age1_filename"]
@@ -60,7 +39,6 @@ def _process_nasc_data(survey, nasc_var_types: dict) -> pd.DataFrame:
             file_path, sheet_name=survey.params["nasc_no_age1_sheetname"]
         )
     else:
-
         # check existence of the file
         file_path = (
             survey.params["data_root_dir"] / survey.params["nasc_all_ages_filename"]
@@ -71,7 +49,7 @@ def _process_nasc_data(survey, nasc_var_types: dict) -> pd.DataFrame:
             file_path, sheet_name=survey.params["nasc_all_ages_sheetname"]
         )
 
-    _check_nasc_df(df, file_path, set(nasc_var_types.keys()))
+    check_column_names(df=df, expected_names=set(nasc_var_types.keys()), path_for_df=file_path)
 
     # obtaining those columns that are required
     df = df[nasc_var_types.keys()]

--- a/EchoPro/data_loader/stratification_data.py
+++ b/EchoPro/data_loader/stratification_data.py
@@ -1,9 +1,6 @@
-from pathlib import Path
-
 import numpy as np
-import pandas as pd
 
-from ..utils.input_checks import check_column_names, check_existence_of_file
+from ..utils.input_checks_read import check_and_read
 
 
 class LoadStrataData:  # TODO: Does it make sense for this to be a class?
@@ -48,29 +45,12 @@ class LoadStrataData:  # TODO: Does it make sense for this to be a class?
         """
 
         if self.survey.params["strata_sheetname"] in ["Base KS", "INPFC"]:
-
-            # check existence of the file
-            file_path = (
-                self.survey.params["data_root_dir"]
-                / self.survey.params["strata_filename"]
+            strata_df = check_and_read(
+                "strata_filename",
+                "strata_sheetname",
+                self.strata_cols_types,
+                self.survey.params
             )
-            check_existence_of_file(file_path)
-
-            # read and check stratification file
-            strata_df = pd.read_excel(
-                file_path, sheet_name=self.survey.params["strata_sheetname"]
-            )
-            check_column_names(
-                df=strata_df,
-                expected_names=set(self.strata_cols_types.keys()),
-                path_for_df=file_path
-            )
-
-            # extract only those columns that are necessary
-            strata_df = strata_df[list(self.strata_cols_types.keys())].copy()
-
-            # set data types of dataframe
-            strata_df = strata_df.astype(self.strata_cols_types)
 
             # set index of dataframe
             strata_df.set_index(["haul_num", "stratum_num"], inplace=True)
@@ -93,29 +73,12 @@ class LoadStrataData:  # TODO: Does it make sense for this to be a class?
         """
 
         if self.survey.params["geo_strata_sheetname"] in ["stratification1", "INPFC"]:
-
-            # check existence of the file
-            file_path = (
-                self.survey.params["data_root_dir"]
-                / self.survey.params["geo_strata_filename"]
+            geo_strata_df = check_and_read(
+                "geo_strata_filename",
+                "geo_strata_sheetname",
+                self.geo_strata_cols_types,
+                self.survey.params
             )
-            check_existence_of_file(file_path)
-
-            # read and check geographic stratification file
-            geo_strata_df = pd.read_excel(
-                file_path, sheet_name=self.survey.params["geo_strata_sheetname"]
-            )
-            check_column_names(
-                df=geo_strata_df,
-                expected_names=set(self.geo_strata_cols_types.keys()),
-                path_for_df=file_path
-            )
-
-            # extract only those columns that are necessary
-            geo_strata_df = geo_strata_df[list(self.geo_strata_cols_types.keys())].copy()
-
-            # set data types of dataframe
-            geo_strata_df = geo_strata_df.astype(self.geo_strata_cols_types)
 
             self.survey.geo_strata_df = geo_strata_df
         else:

--- a/EchoPro/data_loader/stratification_data.py
+++ b/EchoPro/data_loader/stratification_data.py
@@ -33,25 +33,6 @@ class LoadStrataData:  # TODO: Does it make sense for this to be a class?
         self._load_stratification_file()
         self._load_geographic_stratification()
 
-    def _check_strata_df(self, strata_df: pd.DataFrame, df_path: Path) -> None:
-        """
-        Ensures that the appropriate columns are
-        contained in the stratification Dataframe.
-
-        Parameters
-        ----------
-        strata_df: pd.DataFrame
-            The constructed Strata DataFrame
-        df_path: Path
-            The path to the Excel file used to construct the DataFrame
-        """
-
-        # TODO: should we add more in-depth checks here?
-
-        check_column_names(
-            df=strata_df, expected_names=self.strata_cols, path_for_df=df_path
-        )
-
     def _load_stratification_file(self) -> None:
         """
         Loads and checks the stratification file associated
@@ -76,7 +57,7 @@ class LoadStrataData:  # TODO: Does it make sense for this to be a class?
             strata_df = pd.read_excel(
                 file_path, sheet_name=self.survey.params["strata_sheetname"]
             )
-            self._check_strata_df(strata_df, file_path)
+            check_column_names(df=strata_df, expected_names=self.strata_cols, path_for_df=file_path)
 
             # extract only those columns that are necessary
             strata_df = strata_df[["stratum_num", "haul_num", "fraction_hake"]].copy()

--- a/EchoPro/survey.py
+++ b/EchoPro/survey.py
@@ -24,7 +24,7 @@ from .computation import (
 )
 from .data_loader import KrigingMesh, LoadBioData, LoadStrataData, load_nasc_df
 from .reports import Reports
-from .utils.input_checks import check_existence_of_file
+from .utils.input_checks_read import check_existence_of_file
 
 
 class Survey:

--- a/EchoPro/utils/input_checks_read.py
+++ b/EchoPro/utils/input_checks_read.py
@@ -34,7 +34,7 @@ def check_column_names(
         )
 
 
-def check_existence_of_file(file_path: Path):
+def check_existence_of_file(file_path: Path) -> None:
     """
     Makes sure that the input ``file_path`` exists.
 
@@ -53,3 +53,46 @@ def check_existence_of_file(file_path: Path):
         raise FileNotFoundError(
             f"The file '{str(file_path.absolute())}' does not exist."
         )
+
+
+def check_and_read(
+        param_filename: str,
+        param_sheetname: str,
+        cols_types: dict,
+        params: dict
+) -> pd.DataFrame:
+    """
+    For input data table, check file path and column names, read into DataFrame,
+    retain only the target columns, and set the target column data types.
+
+    Parameters
+    ----------
+    param_filename : str
+        Name of configuration parameter specifying the file path
+    param_sheetname : str
+        Name of configuration parameter specifying the Excel file sheet name
+    cols_types : dict
+        Dictionary specifying the column names and types for the target input data
+    params: dict
+        Survey parameter dictionary
+
+    Returns
+    -------
+    pd.DataFrame
+        Read and checked Dataframe
+    """
+    # check existence of the files
+    file_path = params["data_root_dir"] / params[param_filename]
+    check_existence_of_file(file_path)
+
+    # read in and check Excel file
+    df = pd.read_excel(file_path, sheet_name=params[param_sheetname])
+    check_column_names(df=df, expected_names=set(cols_types.keys()), path_for_df=file_path)
+
+    # obtaining those columns that are required
+    df = df[list(cols_types.keys())].copy()
+
+    # set data types of dataframe
+    df = df.astype(cols_types)
+
+    return df


### PR DESCRIPTION
There was a lot of redundancy in the data reading (loading) modules, in the `data_loader` subpackage. I implemented several simplifications:
- Removed `_check_*` functions, moving the column check step into `_load_*` functions. The `_check_*` functions only checked the presence of expected column names, and that was done in a single statement by calling another function. It was unnecessary and bloated to have whole functions dedicated to just that step.
- Define expected input data column names and types just once. Previously, each set of column names was effectively listed three times.
- Created `check_and_read` function in `utils/input_checks.py` (renamed to `input_checks_read.py`) to read and check a data file, retain only the target columns, and set the target column data types. This function is used by all the `_load_*` functions, greatly simplifying the code in each of those functions.
- In `biological_data.py`, move `_process_haul_to_transect_mapping_data` to a more logical location, right after all the other `_process_*` functions. A cosmetic change to improve readability.

This PR doesn't change any functionality. But these simplifications should make other planned changes easier to implement, including #109 and #110.