### PR TITLE
Use hierarchical structure in yaml file to specifiy data files

### DIFF
--- a/EchoPro/data_loader/biological_data.py
+++ b/EchoPro/data_loader/biological_data.py
@@ -200,15 +200,13 @@ class LoadBioData:  # TODO: Does it make sense for this to be a class?
 
         if self.survey.params["source"] == 3:
             df_us = check_and_read(
-                "length_US_filename",
-                "length_US_sheet",
+                "biological/length/US",
                 self.len_cols_types,
                 self.survey.params
             )
 
             df_can = check_and_read(
-                "length_CAN_filename",
-                "length_CAN_sheet",
+                "biological/length/CAN",
                 self.len_cols_types,
                 self.survey.params
             )
@@ -236,15 +234,13 @@ class LoadBioData:  # TODO: Does it make sense for this to be a class?
 
         if self.survey.params["source"] == 3:
             df_us = check_and_read(
-                "specimen_US_filename",
-                "specimen_US_sheet",
+                "biological/specimen/US",
                 self.spec_cols_types,
                 self.survey.params
             )
 
             df_can = check_and_read(
-                "specimen_CAN_filename",
-                "specimen_CAN_sheet",
+                "biological/specimen/CAN",
                 self.spec_cols_types,
                 self.survey.params
             )
@@ -272,15 +268,13 @@ class LoadBioData:  # TODO: Does it make sense for this to be a class?
 
         if self.survey.params["source"] == 3:
             df_us = check_and_read(
-                "catch_US_filename",
-                "catch_US_sheet",
+                "biological/catch/US",
                 self.catch_cols_types,
                 self.survey.params
             )
 
             df_can = check_and_read(
-                "catch_CAN_filename",
-                "catch_CAN_sheet",
+                "biological/catch/CAN",
                 self.catch_cols_types,
                 self.survey.params
             )
@@ -312,15 +306,13 @@ class LoadBioData:  # TODO: Does it make sense for this to be a class?
 
         if self.survey.params["source"] == 3:
             df_us = check_and_read(
-                "filename_haul_to_transect_US",
-                "haul_to_transect_US_sheetname",
+                "biological/haul_to_transect/US",
                 self.haul_to_transect_mapping_cols_types,
                 self.survey.params
             )
 
             df_can = check_and_read(
-                "filename_haul_to_transect_CAN",
-                "haul_to_transect_CAN_sheetname",
+                "biological/haul_to_transect/CAN",
                 self.haul_to_transect_mapping_cols_types,
                 self.survey.params
             )

--- a/EchoPro/data_loader/biological_data.py
+++ b/EchoPro/data_loader/biological_data.py
@@ -66,7 +66,7 @@ class LoadBioData:  # TODO: Does it make sense for this to be a class?
 
         Parameters
         ----------
-        df : Pandas Dataframe
+        df : pd.Dataframe
             Dataframe holding the length data
         haul_num_offset : int
             The offset that should be applied to the ``haul_num`` column
@@ -76,17 +76,15 @@ class LoadBioData:  # TODO: Does it make sense for this to be a class?
         Processed Dataframe
         """
 
-        # extract target species
+        # extract target species and remove species_id column
         df = df.loc[df["species_id"] == self.survey.params["species_id"]]
+        df.drop(columns=["species_id"], inplace=True)
 
         # Apply haul offset
         df["haul_num"] = df["haul_num"] + haul_num_offset
 
         if self.survey.params["exclude_age1"] is False:
             raise NotImplementedError("Including age 1 data has not been implemented!")
-
-        # remove species_id column
-        df.drop(columns=["species_id"], inplace=True)
 
         df.set_index("haul_num", inplace=True)
 
@@ -103,7 +101,7 @@ class LoadBioData:  # TODO: Does it make sense for this to be a class?
 
         Parameters
         ----------
-        df : Pandas Dataframe
+        df : pd.Dataframe
             Dataframe holding the specimen data
         haul_num_offset : int
             The offset that should be applied to the ``haul_num`` column
@@ -113,17 +111,15 @@ class LoadBioData:  # TODO: Does it make sense for this to be a class?
         Processed Dataframe
         """
 
-        # extract target species
+        # extract target species and remove species_id column
         df = df.loc[df["species_id"] == self.survey.params["species_id"]]
+        df.drop(columns=["species_id"], inplace=True)
 
         # Apply haul_num_offset
         df["haul_num"] = df["haul_num"] + haul_num_offset
 
         if self.survey.params["exclude_age1"] is False:
             raise NotImplementedError("Including age 1 data has not been implemented!")
-
-        # remove species_id column
-        df.drop(columns=["species_id"], inplace=True)
 
         # set and organize index
         df.set_index("haul_num", inplace=True)
@@ -146,7 +142,7 @@ class LoadBioData:  # TODO: Does it make sense for this to be a class?
 
         Parameters
         ----------
-        df : Pandas Dataframe
+        df : pd.Dataframe
             Dataframe holding the catch data
         haul_num_offset : int
             The offset that should be applied to the ``haul_num`` column
@@ -156,17 +152,14 @@ class LoadBioData:  # TODO: Does it make sense for this to be a class?
         Processed Dataframe
         """
 
-        # extract target species
+        # extract target species and remove species_id column
         df = df.loc[df["species_id"] == self.survey.params["species_id"]]
+        df.drop(columns=["species_id"], inplace=True)
 
         # Apply haul offset
         df["haul_num"] = df["haul_num"] + haul_num_offset
 
-        # remove species_id column
-        df.drop(columns=["species_id"], inplace=True)
-
         df.set_index("haul_num", inplace=True)
-
         df.sort_index(inplace=True)
 
         return df
@@ -179,7 +172,7 @@ class LoadBioData:  # TODO: Does it make sense for this to be a class?
 
         Parameters
         ----------
-        df : pd. Dataframe
+        df : pd.Dataframe
             Dataframe holding the haul to transect mapping data
 
         Returns

--- a/EchoPro/data_loader/kriging_mesh.py
+++ b/EchoPro/data_loader/kriging_mesh.py
@@ -59,12 +59,7 @@ class KrigingMesh:
         the full mesh and assigns it as the class variable ``mesh_gdf``.
         """
 
-        df = check_and_read(
-            "mesh_filename",
-            "mesh_sheetname",
-            self.mesh_cols_types,
-            self.survey.params
-        )
+        df = check_and_read("kriging/mesh", self.mesh_cols_types, self.survey.params)
 
         # construct geopandas DataFrame to simplify downstream processes
         gdf = gpd.GeoDataFrame(
@@ -88,8 +83,7 @@ class KrigingMesh:
         """
 
         df = check_and_read(
-            "smoothed_contour_filename",
-            "smoothed_contour_sheetname",
+            "kriging/smoothed_contour",
             self.contour_cols_types,
             self.survey.params
         )

--- a/EchoPro/data_loader/nasc_data.py
+++ b/EchoPro/data_loader/nasc_data.py
@@ -26,19 +26,9 @@ def _process_nasc_data(survey, nasc_var_types: dict) -> pd.DataFrame:
 
     # select and check the appropriate nasc data file
     if survey.params["exclude_age1"]:
-        df = check_and_read(
-            "nasc_no_age1_filename",
-            "nasc_no_age1_sheetname",
-            nasc_var_types,
-            survey.params
-        )
+        df = check_and_read("NASC/no_age1", nasc_var_types, survey.params)
     else:
-        df = check_and_read(
-            "nasc_all_ages_filename",
-            "nasc_all_ages_sheetname",
-            nasc_var_types,
-            survey.params
-        )
+        df = check_and_read("NASC/all_ages", nasc_var_types, survey.params)
 
     if survey.params["survey_year"] < 2003:
         # TODO: it may be the case that we need to include lines 35-61 of

--- a/EchoPro/data_loader/stratification_data.py
+++ b/EchoPro/data_loader/stratification_data.py
@@ -44,10 +44,9 @@ class LoadStrataData:  # TODO: Does it make sense for this to be a class?
             Dataframe representation of stratification file.
         """
 
-        if self.survey.params["strata_sheetname"] in ["Base KS", "INPFC"]:
+        if self.survey.params["stratification"]["strata"]["sheetname"] in ["Base KS", "INPFC"]:
             strata_df = check_and_read(
-                "strata_filename",
-                "strata_sheetname",
+                "stratification/strata",
                 self.strata_cols_types,
                 self.survey.params
             )
@@ -72,10 +71,9 @@ class LoadStrataData:  # TODO: Does it make sense for this to be a class?
             Dataframe representation of geographic stratification file.
         """
 
-        if self.survey.params["geo_strata_sheetname"] in ["stratification1", "INPFC"]:
+        if self.survey.params["stratification"]["geo_strata"]["sheetname"] in ["stratification1", "INPFC"]: # noqa
             geo_strata_df = check_and_read(
-                "geo_strata_filename",
-                "geo_strata_sheetname",
+                "stratification/geo_strata",
                 self.geo_strata_cols_types,
                 self.survey.params
             )

--- a/EchoPro/utils/input_checks_read.py
+++ b/EchoPro/utils/input_checks_read.py
@@ -56,8 +56,7 @@ def check_existence_of_file(file_path: Path) -> None:
 
 
 def check_and_read(
-        param_filename: str,
-        param_sheetname: str,
+        param_path_str: str,
         cols_types: dict,
         params: dict
 ) -> pd.DataFrame:
@@ -67,10 +66,9 @@ def check_and_read(
 
     Parameters
     ----------
-    param_filename : str
-        Name of configuration parameter specifying the file path
-    param_sheetname : str
-        Name of configuration parameter specifying the Excel file sheet name
+    param_path_str : str
+        Parameter "path" for the input data file, using "/" as a delimiter.
+        eg, biological/length/US
     cols_types : dict
         Dictionary specifying the column names and types for the target input data
     params: dict
@@ -81,12 +79,19 @@ def check_and_read(
     pd.DataFrame
         Read and checked Dataframe
     """
+
+    # Construct parameter "path" for accessing filename and sheetname
+    param_elements = param_path_str.split("/")
+    param_path = params[param_elements[0]][param_elements[1]]
+    if len(param_elements) == 3:
+        param_path = param_path[param_elements[2]]
+
     # check existence of the files
-    file_path = params["data_root_dir"] / params[param_filename]
+    file_path = params["data_root_dir"] / param_path["filename"]
     check_existence_of_file(file_path)
 
     # read in and check Excel file
-    df = pd.read_excel(file_path, sheet_name=params[param_sheetname])
+    df = pd.read_excel(file_path, sheet_name=param_path["sheetname"])
     check_column_names(df=df, expected_names=set(cols_types.keys()), path_for_df=file_path)
 
     # obtaining those columns that are required

--- a/config_files/survey_year_2019_config.yml
+++ b/config_files/survey_year_2019_config.yml
@@ -4,94 +4,81 @@
 # with the data_root_dir path also set below.
 
 ---
-  ##############################################################################
-  # Parameters
-  #########################################
-  survey_year: 2019            # survey year being considered
-  species_id: 22500            # target species ID for the survey year
-  CAN_haul_offset: 200         # The value to be added to the Canadian's haul number
+##############################################################################
+# Parameters
 
-  hemisphere: NW               # north/south and west/east hemispheres, used for the reports
-  ##############################################################################
+survey_year: 2019            # survey year being considered
+species_id: 22500            # target species ID for the survey year
+CAN_haul_offset: 200         # The value to be added to the Canadian's haul number
+hemisphere: NW               # north/south and west/east hemispheres, used for the reports
 
+##############################################################################
+# Directory path that contains all input data needed
 
-  # directory path that contains all data needed
-  data_root_dir: ../../2019_consolidated_files/
+data_root_dir: /usr/mayorgadat/workmain/acoustics/2021-NWFSC-EchoPro-HakeIGP/EchoPro/EchoProPython/2019_consolidated_files
+#  data_root_dir: ../../2019_consolidated_files/
 
-  ##############################################################################
-  # Paths to biological files #
-  #############################
+##############################################################################
+# Input data files
 
-  # File names and associated sheet name for the US section
-  length_US_filename: Biological/US/2019_biodata_length.xlsx
-  length_US_sheet: biodata_length
-  specimen_US_filename: Biological/US/2019_biodata_specimen_AGES.xlsx
-  specimen_US_sheet: biodata_specimen
-  catch_US_filename: Biological/US/2019_biodata_catch.xlsx
-  catch_US_sheet: biodata_catch
-
-
-  # File names for the Canada section
-  length_CAN_filename: Biological/CAN/2019_biodata_length_CAN.xlsx
-  length_CAN_sheet: biodata_length_CAN
-  specimen_CAN_filename: Biological/CAN/2019_biodata_specimen_CAN_AGES.xlsx
-  specimen_CAN_sheet: biodata_specimen_CAN
-  catch_CAN_filename: Biological/CAN/2019_biodata_catch_CAN.xlsx
-  catch_CAN_sheet: biodata_catch_CAN
-  ##############################################################################
-
-
-  ##############################################################################
-  # Paths to stratification files #
-  #################################
-
-  # file that relates the stratification to the Haul
-  # The two stratification types are found in two sheets: "Base KS" and "INPFC"
-  strata_filename: Stratification/US_CAN strata 2019_final.xlsx
-  strata_sheetname: Base KS
-
-  # file that defines the geographic definition of strata
-  # The two stratification types are found in two sheets: "stratification1" and "INPFC"
-  geo_strata_filename: Stratification/Stratification_geographic_Lat_2019_final.xlsx
-  geo_strata_sheetname: stratification1
-
-  # file that provides NASC values, which do not include age1 values
-  nasc_no_age1_filename: Exports/US_CAN_detailsa_2019_table2y+_ALL_final - updated.xlsx
-  nasc_no_age1_sheetname: Sheet1
-
-  # file that provides NASC values, which include all ages
-  nasc_all_ages_filename: Exports/US_CAN_detailsa_2019_table1y+_ALL_final - updated.xlsx
-  nasc_all_ages_sheetname: Sheet1
-  ##############################################################################
-
-
-  ##############################################################################
-  # Paths to Kriging files #
-  ##########################
-
-  # Mesh filename representing the centroids of the Kriging grid
-  mesh_filename: Kriging_files/Kriging_grid_files/krig_grid2_5nm_cut_centroids_2013.xlsx
-  mesh_sheetname: krigedgrid2_5nm_forChu
-
-  # smoothed contour used to transform the mesh points
-  smoothed_contour_filename: Kriging_files/Kriging_grid_files/transformation_isobath_coordinates.xlsx
-  #  smoothed_contour_filename: Kriging_files/Kriging_grid_files/Smoothing_EasyKrig.xlsx
-  smoothed_contour_sheetname: Smoothing_EasyKrig
-
-  vario_krig_para_filename: Kriging_files/default_vario_krig_settings_2019_US_CAN.xlsx
-  ##############################################################################
-
-
-  ##############################################################################
-  # Path to mapping between hauls and transects #
-  ###############################################
-
-  # File names for the US section
-  filename_haul_to_transect_US: Biological/US/haul_to_transect_mapping_2019.xlsx
-  haul_to_transect_US_sheetname: Sheet1
-
-  # File names for the Canada section
-  filename_haul_to_transect_CAN: Biological/CAN/haul_to_transect_mapping_2019_CAN.xlsx
-  haul_to_transect_CAN_sheetname: Sheet1
-  ##############################################################################
+biological:
+  length:
+    US:
+      filename: Biological/US/2019_biodata_length.xlsx
+      sheetname: biodata_length
+    CAN:
+      filename: Biological/CAN/2019_biodata_length_CAN.xlsx
+      sheetname: biodata_length_CAN
+  specimen:
+    US:
+      filename: Biological/US/2019_biodata_specimen_AGES.xlsx
+      sheetname: biodata_specimen
+    CAN:
+      filename: Biological/CAN/2019_biodata_specimen_CAN_AGES.xlsx
+      sheetname: biodata_specimen_CAN
+  catch:
+    US:
+      filename: Biological/US/2019_biodata_catch.xlsx
+      sheetname: biodata_catch
+    CAN:
+      filename: Biological/CAN/2019_biodata_catch_CAN.xlsx
+      sheetname: biodata_catch_CAN
+  haul_to_transect:
+    US:
+      filename: Biological/US/haul_to_transect_mapping_2019.xlsx
+      sheetname: Sheet1
+    CAN:
+      filename: Biological/CAN/haul_to_transect_mapping_2019_CAN.xlsx
+      sheetname: Sheet1
+stratification:
+  strata:
+    # The two stratification types are found in two sheets: "Base KS" and "INPFC"
+    filename: Stratification/US_CAN strata 2019_final.xlsx
+    sheetname: Base KS
+  geo_strata:
+    # The two stratification types are found in two sheets: "stratification1" and "INPFC"
+    filename: Stratification/Stratification_geographic_Lat_2019_final.xlsx
+    sheetname: stratification1
+NASC:
+  # NASC values
+  no_age1:
+    # file that excludes age1 values
+    filename: Exports/US_CAN_detailsa_2019_table2y+_ALL_final - updated.xlsx
+    sheetname: Sheet1
+  all_ages:
+    # file that includes all ages
+    filename: Exports/US_CAN_detailsa_2019_table1y+_ALL_final - updated.xlsx
+    sheetname: Sheet1
+kriging:
+  mesh:
+    filename: Kriging_files/Kriging_grid_files/krig_grid2_5nm_cut_centroids_2013.xlsx
+    sheetname: krigedgrid2_5nm_forChu
+  smoothed_contour:
+    # filename: Kriging_files/Kriging_grid_files/Smoothing_EasyKrig.xlsx
+    filename: Kriging_files/Kriging_grid_files/transformation_isobath_coordinates.xlsx
+    sheetname: Smoothing_EasyKrig
+  vario_krig_para:
+    # NOTE: This file is not currently used
+    filename: Kriging_files/default_vario_krig_settings_2019_US_CAN.xlsx
+    sheetname: Sheet1
 ...


### PR DESCRIPTION
Re-organized the elements that define the input data files in `survey_year_2019_config.yml` to use a hierarchical structure that clearly groups elements by file type.

Partially addresses #109, and builds on the structure drafted in https://github.com/uw-echospace/EchoPro/issues/111#issuecomment-1751866907