### PR TITLE
docs: Expand API page and finalize Classes and data structures

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -4,12 +4,19 @@ API reference
 **Content**
 
 * `Survey`_
-* `Computational routines`_
-    * :py:class:`Bootstrapping <EchoPro.computation.Bootstrapping>`
-    * :py:class:`Kriging <EchoPro.computation.Kriging>`
-    * :py:class:`Semi-variogram <EchoPro.computation.SemiVariogram>`
 * `Data loading`_
-    * :py:class:`Kriging Mesh <EchoPro.data_loader.KrigingMesh>`
+    * :py:class:`KrigingMesh <EchoPro.data_loader.KrigingMesh>`
+    * :py:class:`LoadBioData <EchoPro.data_loader.LoadBioData>`
+    * :py:class:`LoadStrataData <EchoPro.data_loader.LoadStrataData>`
+    * :py:class:`load_nasc_df <EchoPro.data_loader.load_nasc_df>`
+* `Computational routines`_
+    * :py:class:`Kriging <EchoPro.computation.Kriging>`
+    * :py:class:`SemiVariogram <EchoPro.computation.SemiVariogram>`
+    * :py:class:`ComputeTransectVariables <EchoPro.computation.ComputeTransectVariables>`
+    * :py:class:`ComputeKrigingVariables <EchoPro.computation.ComputeKrigingVariables>`
+    * :py:class:`Bootstrapping <EchoPro.computation.Bootstrapping>`
+* `Reports`_
+    * :py:class:`Reports <EchoPro.reports.Reports>`
 
 
 Survey
@@ -18,15 +25,38 @@ Survey
 .. automodule:: EchoPro
    :members: Survey
 
-Computational routines
-----------------------
-
-.. automodule:: EchoPro.computation
-    :members: Kriging, SemiVariogram, Bootstrapping
-
 
 Data loading
 ------------
 
 .. automodule:: EchoPro.data_loader
-    :members: KrigingMesh
+    :members: KrigingMesh, LoadBioData, LoadStrataData, load_nasc_df
+
+
+Computational routines
+----------------------
+
+Kriging
+^^^^^^^
+
+.. automodule:: EchoPro.computation
+    :members: Kriging, SemiVariogram
+
+Computation of results
+^^^^^^^^^^^^^^^^^^^^^^
+
+.. automodule:: EchoPro.computation
+    :members: ComputeTransectVariables, ComputeKrigingVariables
+
+Bootstrapping
+^^^^^^^^^^^^^
+
+.. automodule:: EchoPro.computation
+    :members: Bootstrapping
+
+
+Reports
+-------
+
+.. automodule:: EchoPro.reports
+    :members: Reports


### PR DESCRIPTION
- Expand docs API page to cover all classes and data loaders. The coverage was not complete.
- TODO: In later commits, will finalize the [Classes and data structures](https://uw-echospace.github.io/EchoPro/classes-datastructures.html) docs page (#113)