### PR TITLE
Ensure new reports are actually generated when `test_reports.py` tests are run

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 _echopro_version.py
 
 # ignore output reports, if they were produced
-EchoPro/tests/reports/EchoPro_python_output
+EchoPro/tests/reports/EchoPro_python_output*
 
 # Created by .ignore support plugin (hsz.mobi)
 ### Python template

--- a/EchoPro/tests/reports/test_reports.py
+++ b/EchoPro/tests/reports/test_reports.py
@@ -1,14 +1,15 @@
-import os
-import pandas as pd
-import numpy as np
-import EchoPro
-from EchoPro.computation import SemiVariogram as SV
 import pathlib
 from typing import List, Optional
 
-# TODO: formalize all tests
+import pandas as pd
+import pytest
+import numpy as np
+
+import EchoPro
+from EchoPro.computation import SemiVariogram as SV
 
 
+@pytest.fixture(scope="module")
 def generate_reports(config_base_path: pathlib.Path,
                      reports_base_path: pathlib.Path) -> None:
     """
@@ -150,6 +151,7 @@ def _compare_truth_produced_files(truth_base_path: pathlib.Path, produced_base_p
             assert np.all(np.isclose(df_truth.to_numpy(), df_produced.to_numpy()))
 
 
+@pytest.mark.usefixtures("generate_reports")
 def test_length_age_reports(config_base_path: pathlib.Path, matlab_output_base_path: pathlib.Path,
                             reports_base_path: pathlib.Path):
     """
@@ -196,6 +198,7 @@ def test_length_age_reports(config_base_path: pathlib.Path, matlab_output_base_p
                                   index_col_produced, sortby)
 
 
+@pytest.mark.usefixtures("generate_reports")
 def test_biomass_ages_reports(config_base_path: pathlib.Path, matlab_output_base_path: pathlib.Path,
                               reports_base_path: pathlib.Path):
     """
@@ -243,6 +246,7 @@ def test_biomass_ages_reports(config_base_path: pathlib.Path, matlab_output_base
                                   index_col_produced, sortby)
 
 
+@pytest.mark.usefixtures("generate_reports")
 def test_core_variables_reports(config_base_path: pathlib.Path, matlab_output_base_path: pathlib.Path,
                                 reports_base_path: pathlib.Path):
     """
@@ -290,6 +294,7 @@ def test_core_variables_reports(config_base_path: pathlib.Path, matlab_output_ba
                                   index_col_produced, sortby)
 
 
+@pytest.mark.usefixtures("generate_reports")
 def test_kriging_input_report(config_base_path: pathlib.Path, matlab_output_base_path: pathlib.Path,
                               reports_base_path: pathlib.Path):
     """
@@ -333,6 +338,7 @@ def test_kriging_input_report(config_base_path: pathlib.Path, matlab_output_base
                                   index_col_produced, sortby)
 
 
+@pytest.mark.usefixtures("generate_reports")
 def test_len_haul_count_reports(config_base_path: pathlib.Path, matlab_output_base_path: pathlib.Path,
                                 reports_base_path: pathlib.Path):
     """


### PR DESCRIPTION
In `test_reports.py`, the function `generate_reports` that generates the report Excel files was not actually set up to run automatically when a test was run; it had to be run manually in advance!
https://github.com/uw-echospace/EchoPro/blob/161163e293bd0024edd3fb1455a4103b3a213503/EchoPro/tests/reports/test_reports.py#L12

I've decorated the function with `@pytest.fixture(scope="module")` (see [here](https://docs.pytest.org/en/latest/how-to/fixtures.html#fixture-scopes)) and all the actual tests with `@pytest.mark.usefixtures("generate_reports")` (see [here](https://docs.pytest.org/en/latest/how-to/fixtures.html#use-fixtures-in-classes-and-modules-with-usefixtures)) to ensure `generate_reports` is called whenever a `test_reports.py` test is run. If multiple tests are run, `generate_reports` is run only once, with the first test; there is no need to run it again for every test.